### PR TITLE
Handle case with events that do not have duration or dt_end

### DIFF
--- a/icalcli/icalcli.py
+++ b/icalcli/icalcli.py
@@ -915,12 +915,15 @@ class IcalendarInterface:
         AND
         a) the date based search (unless both start & end are None)
         """
+        event_start = self._to_datetime(event.Decoded('dtstart'))
         if 'dtend' in event:
             event_end = self._to_datetime(event.Decoded('dtend'))
-        else:
+        elif 'duration' in event:
             event_end = self._to_datetime(event.Decoded('dtstart')
                                           + event.Decoded('duration'))
-        event_start = self._to_datetime(event.Decoded('dtstart'))
+        else:
+            # special case where an event is punctual and has no end date
+            event_end = event_start
         date_in_range = not ((start and event_end < start) or
                              (end and event_start > end))
         flags = re.I if ignore_case else 0


### PR DESCRIPTION
Handle them like a punctual event for the purpose of listing.

Helps with managing end-less events such as

```ical
BEGIN:VEVENT
DTSTART:20210628T133000Z
DTSTAMP:20220720T070451Z
UID:foobarbaz@google.com
CREATED:20210628T081511Z
DESCRIPTION:
LAST-MODIFIED:20210628T121053Z
LOCATION:
SEQUENCE:1
STATUS:CONFIRMED
SUMMARY:An example event without an End
TRANSP:OPAQUE
END:VEVENT
```
I have these in my professional agenda for example.